### PR TITLE
Make Readstream Emit Close and End Events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
     ChildProcess,
     ChildProcessWithoutNullStreams,
     execFile,
+    exec,
     ExecFileException,
     spawn,
     SpawnOptionsWithoutStdio,
@@ -322,7 +323,8 @@ export default class YTDlpWrap {
         process: ChildProcess
     ): void {
         signal?.addEventListener('abort', () => {
-            process.kill();
+            if (os.platform() === 'win32') exec('taskkill /pid ' + process.pid + ' /T /F')
+            else process.kill();
         });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,11 +263,16 @@ export default class YTDlpWrap {
         ytDlpProcess.on('error', (error) => (processError = error));
 
         ytDlpProcess.on('close', (code) => {
-            if (code === 0 || ytDlpProcess.killed) readStream.destroy();
-            else
-                readStream.destroy(
-                    YTDlpWrap.createError(code, processError, stderrData)
-                );
+            if (code === 0 || ytDlpProcess.killed){
+                readStream.emit('close', code);
+                readStream.emit('end');
+                readStream.destroy();
+            }
+            else{
+                const error = YTDlpWrap.createError(code, processError, stderrData)
+                readStream.emit( 'error', error );
+                readStream.destroy( error );
+            }
         });
         return readStream;
     }


### PR DESCRIPTION
If you pipe, many writable streams listen to the end event (ex. Google Cloud Storage). This event should be emitted once the close event is detected on the ytDLP process.