### PR TITLE
[FIX] ETXTBSY

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,10 +173,11 @@ export default class YTDlpWrap {
         message: IncomingMessage,
         filePath: string
     ): Promise<IncomingMessage> {
+        const file = fs.createWriteStream(filePath);
         return new Promise<IncomingMessage>((resolve, reject) => {
-            message.pipe(fs.createWriteStream(filePath));
+            message.pipe(file);
             message.on('error', (e) => reject(e));
-            message.on('end', () =>
+            file.on('finish', () =>
                 message.statusCode == 200 ? resolve(message) : reject(message)
             );
         });


### PR DESCRIPTION
Issue because the promise ends before the file is unlocked.
I saw the problem when i needed to use the class right after downloading the binary.
To fix instead of getting the message event, I put the Writer event!