### PR TITLE
[FIX] progressRegex

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { stdout } from 'process';
 
 const executableName = 'yt-dlp';
 const progressRegex =
-    /\[download\] *(.*) of ([^ ]*)(:? *at *([^ ]*))?(:? *ETA *([^ ]*))?/;
+    /\[download\] *(.*) of *([^ ]*)(:? *at *([^ ]*))?(:? *ETA *([^ ]*))?/;
 
 //#region YTDlpEventEmitter
 


### PR DESCRIPTION
Add missing 'zero or more' `*` quantifier to progressRegex that fixes not reporting the progress correctly.

Before:
`{"percent":66.3,"totalSize":""}`

After:
`{"percent":45.6,"totalSize":"21.41MiB","currentSpeed":"5.83MiB/s","eta":"00:02"}`

Thank you for maintaining this node module.