### PR TITLE
Don't close the readSteam manually

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,9 +331,7 @@ export default class YTDlpWrap {
 
         ytDlpProcess.on('close', (code) => {
             if (code === 0 || ytDlpProcess.killed) {
-                readStream.emit('close');
-                readStream.destroy();
-                readStream.emit('end');
+                readStream.push(null);
             } else {
                 const error = YTDlpWrap.createError(
                     code,


### PR DESCRIPTION
Allow consumers to close the readStream when they finish consuming the readStream. Otherwise ERR_STREAM_PREMATURE_CLOSE is thrown.